### PR TITLE
Revert "MAA1:n ja MAA2:n tekijöihin Sanni Ketoluoto" (oli jo lisätty aiemmin)

### DIFF
--- a/config/authors.tex
+++ b/config/authors.tex
@@ -45,7 +45,6 @@
 § Ville Tilvis
 § Jaakko Viertiö
 § Emilia Välttilä
-§ Sanni Ketoluoto
 }
 
 \subsection*{Tekijät (MAA2)}
@@ -71,7 +70,6 @@
 § Paula Thitz
 § Sampo Tiensuu
 § Ville Tilvis
-§ Sanni Ketoluoto
 }
 
 \subsection*{Kiitokset}


### PR DESCRIPTION
Reverts avoimet-oppimateriaalit-ry/vapaa-matikka-vol1#2
